### PR TITLE
Imports typo on description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,9 @@ Imports:
   purrr,
   dplyr,
   naptime,
-  jsonlite
+  jsonlite,
+  furrr,
+  lubridate
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -2,5 +2,5 @@ pandoc: 2.7.3
 pkgdown: 1.5.1
 pkgdown_sha: ~
 articles: []
-last_built: 2020-06-30T20:00Z
+last_built: 2020-07-03T00:12Z
 


### PR DESCRIPTION
Fixing description typo that didn't include lubridate & furrr